### PR TITLE
Bug: pip wheel has no metadata about tessagon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed `compas_libigl` plugins are not detected.
+* Change requirements.txt to pyproject.toml.
 
 ### Removed
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - cmake
   - compas
+  - tessagon
   - pip:
       - -r requirements-dev.txt
       - .

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - cmake
   - compas
-  - tessagon
   - pip:
+      - tessagon
       - -r requirements-dev.txt
       - .

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,5 @@ dependencies:
   - cmake
   - compas
   - pip:
-      - tessagon
       - -r requirements-dev.txt
-      - -r requirements.txt
       - .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+compas >=2.0.0
+tessagon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-compas >=2.0.0
-tessagon


### PR DESCRIPTION
3rd-party requirements to pyproject.toml: https://github.com/compas-dev/compas_libigl/issues/36

Change: Moved from setuptools.dynamic with requirements.txt to PEP 621 native dependencies and dependency groups (PEP 735) based on this discussion: https://github.com/scikit-build/scikit-build-core/issues/1098

Why:

- More modern, standards-compliant metadata (works without setuptools).
- Dependencies are now declarative in pyproject.toml rather than spread across multiple files.
- Groups (dev, tests, docs) replace optional-dependencies, making environments easier to reproduce with modern tools like uv or pip-tools.

Before: 
```toml
dynamic = ['dependencies', 'optional-dependencies', 'version']



[tool.setuptools.dynamic]
dependencies = { file = "requirements.txt" }
optional-dependencies = { dev = { file = "requirements-dev.txt" } }
```

After: 

```toml
dynamic = ['version']
dependencies = [
    "compas >=2.0.0",
    "tessagon",
]

[dependency-groups]
dev = [
    "ruff",
    "pre-commit",
    "build",
    { include-group = "tests" },
    { include-group = "docs" },
]
tests = [
    "pytest",
    "numpy",
]
docs = [
    "sphinx",
    "sphinx-compas-theme",
]
```
